### PR TITLE
FIX: some concurrency problems

### DIFF
--- a/sffs.c
+++ b/sffs.c
@@ -750,18 +750,18 @@ int sf_node_lock(int mode, struct sf_node *node)
         goto err;
     }
 
-    if (!(mode & NODE_LOCK_MODE_RD) && !(mode & NODE_LOCK_MODE_WR)) {
+    if (!(mode & NODE_LOCKMODE_R) && !(mode & NODE_LOCKMODE_W)) {
         ret = ENOTSUP;
         goto err;
     }
 
     sf_util_mutex_lock(&(node->lock));
-    while (node->writing || (mode & NODE_LOCK_MODE_WR && node->reading))
+    while (node->writing || (mode & NODE_LOCKMODE_W && node->reading))
         sf_util_cond_wait(&(node->cond), &(node->lock));
 
-    if (mode & NODE_LOCK_MODE_RD)
+    if (mode & NODE_LOCKMODE_R)
         node->reading++;
-    else if (mode & NODE_LOCK_MODE_WR)
+    else if (mode & NODE_LOCKMODE_W)
         node->writing = 1;
     sf_util_mutex_unlock(&(node->lock));
 
@@ -785,15 +785,15 @@ int sf_node_unlock(int mode, struct sf_node *node)
         goto err;
     }
 
-    if (!(mode & NODE_LOCK_MODE_RD) && !(mode & NODE_LOCK_MODE_WR)) {
+    if (!(mode & NODE_LOCKMODE_R) && !(mode & NODE_LOCKMODE_W)) {
         ret = ENOTSUP;
         goto err;
     }
 
     sf_util_mutex_lock(&(node->lock));
-    if (mode & NODE_LOCK_MODE_RD)
+    if (mode & NODE_LOCKMODE_R)
         node->reading--;
-    else if (mode & NODE_LOCK_MODE_WR)
+    else if (mode & NODE_LOCKMODE_W)
         node->writing = 0;
     sf_util_cond_signal(&(node->cond));
     sf_util_mutex_unlock(&(node->lock));

--- a/sffs.h
+++ b/sffs.h
@@ -17,8 +17,8 @@
 #define PATH_MAX 4096
 #define DIR_DELIMITER "/"
 
-#define NODE_LOCK_MODE_RD 0
-#define NODE_LOCK_MODE_WR 1
+#define NODE_LOCKMODE_R 1
+#define NODE_LOCKMODE_W 2
 
 struct sf_blocklist_item {
     size_t addr;

--- a/util.c
+++ b/util.c
@@ -37,12 +37,12 @@ void sf_util_mutex_lock(pthread_mutex_t *lock)
 {
     int ret;
 
-    sf_log_debug("sf_util_mutex_lock(lock=%p): %s\n", lock);
+    sf_log_debug("sf_util_mutex_lock(lock=%p)\n", lock);
 
     ret = pthread_mutex_lock(lock);
 
     if (ret != 0) {
-        sf_log_fatal("sf_util_mutex_unlock(lock=%p): %s\n", lock, strerror(ret));
+        sf_log_fatal("sf_util_mutex_lock(lock=%p): %s\n", lock, strerror(ret));
         exit(EXIT_FAILURE);
     }
 }
@@ -65,7 +65,7 @@ void sf_util_cond_wait(pthread_cond_t *cond, pthread_mutex_t *lock)
 {
     int ret;
 
-    sf_log_debug("sf_util_cond_wait(cond=%p, lock=%p): %s\n", cond, lock);
+    sf_log_debug("sf_util_cond_wait(cond=%p, lock=%p)\n", cond, lock);
 
     ret = pthread_cond_wait(cond, lock);
 


### PR DESCRIPTION
- There was the possibility to get wrong nodes: the searched file's
inode number could be released and reserved to another node before
getting the correct node. This two-step operation used to use two
locks, but now, only one lock is being used, making it atomic;
- Wrong usage of node lock mode: nodes were always being locked in read
mode;
- Refactor of node lock mode;
- Fix of debug messages.